### PR TITLE
Replace active wait loop with a sleep in the Query thread.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.class
+.classpath
+.project
+
+# Package Files #
+*.jar
+*.war
+*.ear


### PR DESCRIPTION
The conditional on line 500 ( if (thisNow > nextQueryMillis) {... ) is executed in a tight loop, so if the next query time isn't reached yet, the condition is immediately tested again.  By default, the time between query intervals is 15 seconds.  If the number of queries attempted per interval is relatively small, the amount of time the query thread spins on the conditional will eat cpu resources and distort the results. 

This pull request replaces the active wait with a precisely calculated sleep.  In addition, unused imports are remove.